### PR TITLE
fix rule.declarations.length undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ CSSCombine.prototype._read = function() {
             parse(content, next)
           }))
       }
-      else if (!rule.declarations.length) {
+      else if (rule.declarations && !rule.declarations.length) {
         thy.push(rule.selectors.join(',\n') + ' {}\n')
         next()    
       }


### PR DESCRIPTION
``` bash
/Users/chenchen/fuqiang/dev/newcblog/node_modules/css-combine/index.js:112
      else if (!rule.declarations.length) {
                                 ^
TypeError: Cannot read property 'length' of undefined
    at loop (/Users/chenchen/fuqiang/dev/newcblog/node_modules/css-combine/index.js:112:34)
    at parse (/Users/chenchen/fuqiang/dev/newcblog/node_modules/css-combine/index.js:124:7)
    at ConcatStream.cb (/Users/chenchen/fuqiang/dev/newcblog/node_modules/css-combine/index.js:130:7)
    at ConcatStream.end (/Users/chenchen/fuqiang/dev/newcblog/node_modules/css-combine/node_modules/concat-stream/index.js:44:21)
    at ReadStream.onend (_stream_readable.js:483:10)
    at ReadStream.g (events.js:175:14)
    at ReadStream.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:920:16
    at process._tickCallback (node.js:415:13)
```
